### PR TITLE
Add cache-busting to CSS and JS assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ web/app/uploads/*
 /web/app/themes/ppj/dest/*.html
 /web/app/themes/ppj/vendor/
 /web/app/themes/ppj/temp-auth/.htpasswd
-/web/app/themes/ppj/mix-manifest.json
+/web/app/themes/ppj/dest/mix-manifest.json
 
 # WordPress
 web/wp

--- a/web/app/themes/ppj/functions.php
+++ b/web/app/themes/ppj/functions.php
@@ -4,15 +4,15 @@ namespace ppj;
 function enqueue_scripts()
 {
 
-    $root_dir = get_template_directory_uri();
-    wp_enqueue_style('main-css', $root_dir . mix_asset('/dest/css/main.css'), null, false);
-    wp_enqueue_script('main-js', $root_dir . mix_asset('/dest/js/main.js'), null, false, true);
+    $root_dir = get_template_directory_uri() . '/dest';
+    wp_enqueue_style('main-css', $root_dir . mix_asset('/css/main.css'), null, null);
+    wp_enqueue_script('main-js', $root_dir . mix_asset('/js/main.js'), null, null, true);
 }
 add_action('wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts');
 
 function mix_asset($filename)
 {
-    $manifest_path = dirname(__FILE__) . '/mix-manifest.json';
+    $manifest_path = dirname(__FILE__) . '/dest/mix-manifest.json';
     $manifest = json_decode(file_get_contents($manifest_path), true);
     if (!isset($manifest[$filename])) {
         error_log("Mix asset '$filename' does not exist in manifest.");

--- a/web/app/themes/ppj/webpack.mix.js
+++ b/web/app/themes/ppj/webpack.mix.js
@@ -1,19 +1,16 @@
-const
-    mix = require('laravel-mix'),
-    dest = 'dest/'
-;
+const mix = require('laravel-mix');
 
-mix.js('src/js/main.js'        , dest + 'js')
-    .sass('src/sass/main.sass' , dest + 'css')
-    .copy('src/img/*'          , dest + 'img/')
-    .copy('src/img/svg/*'      , dest + 'img/svg/')
-    .copy('src/html/*'         , dest + '')
-    .copy('src/fonts/*'        , dest + 'fonts')
-    .sourceMaps()
+mix.setPublicPath('./dest/');
 
+mix.js('src/js/main.js'        , 'dest/js')
+    .sass('src/sass/main.sass' , 'dest/css')
+    .copy('src/img/*'          , 'dest/img/')
+    .copy('src/img/svg/*'      , 'dest/img/svg/')
 ;
 
 if (mix.inProduction()) {
-    //mix.version();
+    mix.version();
 }
-
+else {
+    mix.sourceMaps();
+}


### PR DESCRIPTION
This PR adds support for cache-busting of CSS and JS assets.

- Enables versioning on Laravel Mix
- Disables source map generation for production (because it wasn't working anyway, and will require further fiddling to get working)