### PR TITLE
Fix positioning of cookie consent bar

### DIFF
--- a/web/app/themes/ppj/src/sass/main.sass
+++ b/web/app/themes/ppj/src/sass/main.sass
@@ -102,6 +102,12 @@ a[href=""]
 *[v-cloak]
   opacity: 0
 
+// Cookie Consent (WordPress plugin)
+// Override some styles to ensure the cookie message plays nicely with this theme
+#catapult-cookie-bar
+  z-index: 1 !important
+  position: absolute !important
+
 // globals
 
 .medium


### PR DESCRIPTION
I've changed the `z-index` rule of the cookie consent bar so that it won't sit on top of the navigation menu. Due to the layout of elements and the way `z-index` rules cascade, the cookie bar will now no longer float above the main page container. This should be fine, since it's configured to disappear on page scroll anyway so won't stick around for long anyway.

I've also changed the `position` to `absolute` so that it won't float underneath the page container, but instead just sit at the top of the page.

Unfortunately I've had to use `!important` rules to override the styles that the cookie consent plugin embeds directly into the page.