### PR TITLE
Remove `maximum-scale` property from `viewport` meta tag

### DIFF
--- a/web/app/themes/ppj/header.php
+++ b/web/app/themes/ppj/header.php
@@ -8,7 +8,7 @@ $htmlMetaDescription = get_field('html_meta_description');
 <head>
     <meta charset="<?php bloginfo('charset'); ?>">
     <title><?= $htmlTitle ?></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="<?= $htmlMetaDescription ?>" />
     <link href="https://fonts.googleapis.com/css?family=Barlow:300,400,500,600,700" rel="stylesheet">
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDDplfBkLzNA3voskfGyExYnQ46MJ0VtpA"></script>


### PR DESCRIPTION
This change improves accessibility by removing an unnecessary restriction which disabled pinch-and-zoom functionality on some touch devices.

Apple devices have ignored this property since iOS 10, so this really only affected Android users.

More information here: https://a11yproject.com/posts/never-use-maximum-scale/