### PR TITLE
Job search and map improvements

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,7 +1,4 @@
 version: 0.1
-environment_variables:
-  plaintext:
-    APPNAME: "ppj"
 phases:
   pre_build:
     commands:

--- a/web/app/themes/ppj/functions.php
+++ b/web/app/themes/ppj/functions.php
@@ -12,7 +12,7 @@ function enqueue_scripts()
     wp_enqueue_script( 'wistia', '//fast.wistia.com/assets/external/E-v1.js', null, null, true );
 
     if (is_page_template('find-a-job.php')) {
-        wp_enqueue_script( 'google-maps-js','https://maps.googleapis.com/maps/api/js?key=AIzaSyDDplfBkLzNA3voskfGyExYnQ46MJ0VtpA', null, null, true );
+        wp_enqueue_script( 'google-maps-js','https://maps.googleapis.com/maps/api/js?key=AIzaSyDDplfBkLzNA3voskfGyExYnQ46MJ0VtpA&libraries=places', null, null, true );
         wp_enqueue_script( 'find-a-job-js', $root_dir . mix_asset('/js/find-a-job.js'), ('google-maps.js'), null, true );
     }
 }

--- a/web/app/themes/ppj/src/js/CustomMarker.js
+++ b/web/app/themes/ppj/src/js/CustomMarker.js
@@ -100,11 +100,12 @@ CustomMarker.prototype.draw = function() {
 
 };
 
+CustomMarker.prototype.onRemove = function() {
+  this.div.parentNode.removeChild(this.div);
+};
+
 CustomMarker.prototype.remove = function() {
-    if (this.div) {
-        this.div.parentNode.removeChild(this.div);
-        this.div = null;
-    }
+  this.setMap(null);
 };
 
 CustomMarker.prototype.getPosition = function() {

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -31,7 +31,7 @@
       <div class="find-a-job__geolocation"
            :class="{
                 'find-a-job__geolocation--is-busy': (geoLocationIsBusy == true),
-                'find-a-job__geolocation--is-active': searchTerm.isGeolocationSearch
+                'find-a-job__geolocation--is-active': searchTerm.isGeolocation
             }">
         <a class="find-a-job__geolocation-button"
            v-if="geoLocationIsAvailable"
@@ -225,10 +225,11 @@
 
         searchTerm: {
           input: this.storeGet('searchTerm.query') || '',
-          query: null,
+          query: '',
           latlng: null,
           marker: null,
-          isGeolocation: false
+          isGeolocation: false,
+          doneInitialZoom: false
         },
 
         mapSrc: '',
@@ -323,6 +324,15 @@
 
         const coords = this.convertGroupIdToCoords(groupId);
         this.recenterMap(coords.lat, coords.lng);
+
+        if (
+          !this.searchTerm.isGeolocation &&
+          !this.searchTerm.query &&
+          !this.searchTerm.doneInitialZoom
+        ) {
+          this.zoomBy(2);
+          this.searchTerm.doneInitialZoom = true;
+        }
       },
 
       recenterMap(lat, lng) {
@@ -520,6 +530,7 @@
 
       handleNewSearchLocation(latlng) {
         this.searchResults.listView.activePage = 0;
+        this.searchTerm.doneInitialZoom = false;
 
         if (latlng == null) {
           this.removeSearchTermMarker();
@@ -556,7 +567,7 @@
         this.searchTerm.input = '';
         this.searchTerm.query = '';
         this.searchTerm.latlng = null;
-        this.searchTerm.isGeolocationSearch = false;
+        this.searchTerm.isGeolocation = false;
         this.$refs.searchInput.focus();
 
         this.removeSearchTermMarker();
@@ -564,7 +575,7 @@
 
       search() {
         this.searchTerm.query = this.searchTerm.input;
-        this.searchTerm.isGeolocationSearch = false;
+        this.searchTerm.isGeolocation = false;
 
         if (this.searchTerm.query) {
           new google.maps.Geocoder().geocode(
@@ -585,7 +596,7 @@
             };
             this.searchTerm.query = '';
             this.searchTerm.input = '';
-            this.searchTerm.isGeolocationSearch = true;
+            this.searchTerm.isGeolocation = true;
             this.geoLocationIsBusy = false;
             this.geoLocationIsActive = true;
           },

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -218,27 +218,26 @@
             forwardEnabled: true,
             backwardEnabled: false
           },
-          jobs: [], //dummyJobs,
+          jobs: [],
           jobLocationGroups: {},
           orderedJobLocationGroups: [],
           searchTerm: this.storeGet('searchResults.searchTerm') || '',
           searchTermMarker: {},
+          searchTermLatLng: null,
           selectedJobLocationGroupId: '',
           visibleJobLocationGroup: null,
         },
 
         mapSrc: '',
 
-        defaultZoomLevel: 7,
-        defaultMobileZoomLevel: 6,
-        defaultZoomInAmount: 2,
-        initialZoomFlag: false,
+//        defaultZoomLevel: 7,
+//        defaultMobileZoomLevel: 6,
+//        defaultZoomInAmount: 2,
+//        initialZoomFlag: false,
         maxZoom: 25,
         minZoom: 5,
 
         mapOptions: {
-          zoom: 7,
-          center: new google.maps.LatLng(52.4832138, -1.5947146),
           disableDefaultUI: false,
           streetViewControl: false,
           fullscreenControl: false,
@@ -322,12 +321,12 @@
         this.zoomTo(this.map.getZoom() + amount);
       },
 
-      initialZoom() {
+      /*initialZoom() {
         if (!this.initialZoomFlag) {
           this.initialZoomFlag = true;
           this.zoomTo(this.defaultZoomLevel + this.defaultZoomInAmount);
         }
-      },
+      },*/
 
       focusOnJobLocationGroup(groupId) {
         this.updateSelectedJobLocationGroupId(groupId);
@@ -335,7 +334,7 @@
 
         const coords = this.convertGroupIdToCoords(groupId);
         this.recenterMap(coords.lat, coords.lng);
-        this.initialZoom();
+//        this.initialZoom();
       },
 
       recenterMap(lat, lng) {
@@ -484,16 +483,19 @@
       },
 
       createMap() {
-        if (this.isDeviceMobile()) {
-          this.mapOptions.zoom = this.defaultMobileZoomLevel;
-        } else {
-          this.mapOptions.zoom = this.defaultZoomLevel;
-        }
-
         this.map = new google.maps.Map(
-          document.getElementsByClassName('find-a-job__map')[0]
-          , this.mapOptions
+          document.getElementsByClassName('find-a-job__map')[0],
+          this.mapOptions
         );
+        this.zoomToEngland();
+      },
+
+      zoomToEngland() {
+        const england = new google.maps.LatLngBounds(
+          new google.maps.LatLng(49.8647411, -6.418545799999947),
+          new google.maps.LatLng(55.81165979999999, 1.7629159000000527)
+        );
+        this.map.fitBounds(england, 0);
       },
 
       deleteSearchTermMarker() {
@@ -516,13 +518,36 @@
 
       },
 
+      zoomToNearbyResults(lat, lng) {
+        var bounds = new google.maps.LatLngBounds();
+
+        // Add user's search location to the bounds
+        bounds.extend({lat: lat, lng: lng});
+
+        // Add closest tenth of search results to the bounds
+        const locations = this.searchResults.orderedJobLocationGroups;
+        const minVisible = Math.ceil(locations.length / 10);
+        const boundLocations = locations.slice(0, minVisible);
+        boundLocations.forEach((location) => {
+          let ll = {
+            lat: location[0].prison_location.lat,
+            lng: location[0].prison_location.lng
+          };
+          bounds.extend(ll);
+        });
+
+        // Fit the map to the bounds
+        this.map.fitBounds(bounds);
+      },
+
       handleNewSearchLocation(lat, lng) {
         this.searchResults.listView.activePage = 0;
         this.updateJobsDistance(lat, lng);
         this.updateSearchTermMarker(lat, lng);
-        this.recenterMap(lat, lng);
-        this.initialZoomflag = false;
-        this.initialZoom();
+//        this.recenterMap(lat, lng);
+//        this.initialZoomflag = false;
+//        this.initialZoom();
+        this.zoomToNearbyResults(lat, lng);
       },
 
       processGeocoderResults(results, status) {

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -23,7 +23,8 @@
 
         <button class="find-a-job__button-search"
                 type="submit"
-                :disabled="searchTerm.input == ''">
+                :disabled="searchTerm.input == ''"
+                @click="search">
           <div class="find-a-job__button-search-circle"></div>
           <div class="find-a-job__button-search-rectangle"></div>
         </button>

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -305,9 +305,9 @@
       },
 
       zoomTo(level) {
-        if (level >= this.minZoom && level <= this.maxZoom) {
-          this.map.setZoom(level);
-        }
+        if (level < this.minZoom) level = this.minZoom;
+        if (level > this.maxZoom) level = this.maxZoom;
+        this.map.setZoom(level);
       },
 
       zoomBy(amount) {

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -12,7 +12,8 @@
                class="find-a-job__input"
                :placeholder="placeHolderText"
                v-model="searchTerm.input"
-               ref="searchInput" />
+               ref="searchInput"
+               tabindex="1" />
         <div class="find-a-job__button-clear-search-container">
           <button class="find-a-job__button-clear-search"
                   type="reset"

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -230,12 +230,8 @@
 
         mapSrc: '',
 
-//        defaultZoomLevel: 7,
-//        defaultMobileZoomLevel: 6,
-//        defaultZoomInAmount: 2,
-//        initialZoomFlag: false,
-        maxZoom: 25,
-        minZoom: 5,
+        maxZoom: 18,
+        minZoom: 4,
 
         mapOptions: {
           disableDefaultUI: false,
@@ -243,10 +239,7 @@
           fullscreenControl: false,
           mapTypeControl: false,
           gestureHandling: 'greedy',
-          zoomControl: false,
-          zoomControlOptions: {
-            position: google.maps.ControlPosition.TOP_RIGHT
-          },
+          zoomControl: false
         },
 
         titleText: this.title,
@@ -321,20 +314,12 @@
         this.zoomTo(this.map.getZoom() + amount);
       },
 
-      /*initialZoom() {
-        if (!this.initialZoomFlag) {
-          this.initialZoomFlag = true;
-          this.zoomTo(this.defaultZoomLevel + this.defaultZoomInAmount);
-        }
-      },*/
-
       focusOnJobLocationGroup(groupId) {
         this.updateSelectedJobLocationGroupId(groupId);
         CustomMarker.changeSelectedMarkerByGroupId(groupId);
 
         const coords = this.convertGroupIdToCoords(groupId);
         this.recenterMap(coords.lat, coords.lng);
-//        this.initialZoom();
       },
 
       recenterMap(lat, lng) {
@@ -544,9 +529,6 @@
         this.searchResults.listView.activePage = 0;
         this.updateJobsDistance(lat, lng);
         this.updateSearchTermMarker(lat, lng);
-//        this.recenterMap(lat, lng);
-//        this.initialZoomflag = false;
-//        this.initialZoom();
         this.zoomToNearbyResults(lat, lng);
       },
 
@@ -752,25 +734,10 @@
       console.log('job list message URL: ' , this.jobListMessageURL);
 
       axios.get(this.vacanciesDataURL,  { responseType: 'json' })
-        .then(
-         /* response => {
-
-          //self.searchResults.jobs = response.data;
-          self.searchResults.jobs = dummyJobs;
-
-          if (self.searchResults.searchTerm) {
-            self.search();
-          } else {
-
-          }
-        }*/
-          self.handleGotVacanciesData
-        )
+        .then(self.handleGotVacanciesData)
         .catch(function (error) {
           console.log(error);
         });
-
-      //self.handleGotVacanciesData();
 
       this.restorePageData();
     }


### PR DESCRIPTION
This introduces some improvements to the 'find a job' search and map functionality:

- Map will auto-zoom/pan when displaying search results to include the user's search location and ⅒<sup>th</sup> of the search results (with a minimum of 1 result). So with the current number of live vacancies, this will typically mean ~1 vacancy on YCS, and ~6 vacancies on PO.
- The default map view will now fit to England. This uses Google's `fitToBounds` method, so the appropriate zoom level is set dependent on the size of the viewport.
- Resetting the search term will now reset the map to fit England.
- Refactor some of the behaviour around the removal of the `CustomMarker` which represents the user's search location. There was a strange behaviour where the old marker sometimes wasn't removed when the search location changed.
- Implement [Google Places Autocomplete](https://developers.google.com/maps/documentation/javascript/places-autocomplete) to suggest place names on the search input.

Other changes in this branch:

- I've tweaked `buildspec.yml` to remove the `APPNAME` environment variable. Paired with [ministryofjustice/wp-cloudformation-templates PR #9](https://github.com/ministryofjustice/wp-cloudformation-templates/pull/9) this makes it simpler to deploy one codebase to multiple pipelines by removing the need to specify the pipeline name in the code.