### PR TITLE
Add theme support for navigation menu locations

### DIFF
--- a/web/app/themes/ppj/functions.php
+++ b/web/app/themes/ppj/functions.php
@@ -1,6 +1,5 @@
 <?php
-
-use ppj\LegNav;
+namespace ppj;
 
 function enqueue_scripts()
 {

--- a/web/app/themes/ppj/functions.php
+++ b/web/app/themes/ppj/functions.php
@@ -44,3 +44,35 @@ function registerImagesSizes()
     add_image_size( 'header-large-home', 1440, 624, true );
 }
 add_action('init', __NAMESPACE__ . '\\registerImagesSizes');
+
+/**
+ * Register the navigation menu locations that this theme supports
+ */
+function registerNavLocations() {
+    register_nav_menus([
+        'site-wide' => 'Site-wide menu',
+        'prison-officer' => 'Prison Officer menu',
+        'youth-custody' => 'Youth Custody menu',
+    ]);
+}
+add_action('init', __NAMESPACE__ . '\\registerNavLocations');
+
+/**
+ * Get nav menu items for the given theme location
+ *
+ * This is a convenience wrapper around wp_get_nav_menu_items(),
+ * so expect the same output
+ *
+ * @param string $location
+ * @return array
+ */
+function navMenuItems($location) {
+    $menus = get_nav_menu_locations();
+    if (!isset($menus[$location])) {
+        // There's no menu set for this location. Gracefully fail.
+        return [];
+    }
+    else {
+        return wp_get_nav_menu_items($menus[$location]);
+    }
+}

--- a/web/app/themes/ppj/partials/headerNavigationMenu.php
+++ b/web/app/themes/ppj/partials/headerNavigationMenu.php
@@ -2,7 +2,7 @@
 use ppj\LegNav;
 global $post;
 
-$modifiedSiteWideNavItems = ppj\markCurrentlySelectedAncestorMenuItem(wp_get_nav_menu_items('site-wide-nav'));
+$modifiedSiteWideNavItems = ppj\markCurrentlySelectedAncestorMenuItem(ppj\navMenuItems('site-wide'));
 $logoTargetUrl = LegNav\legHomeUrl();
 
 ?>
@@ -29,7 +29,7 @@ $logoTargetUrl = LegNav\legHomeUrl();
         <a href="<?= $logoTargetUrl ?>" class="leg-specific-nav__logo"></a>
 
         <?php if (LegNav\onLeg()):
-            $legNavMenuItems = wp_get_nav_menu_items( LegNav\legName() );
+            $legNavMenuItems = ppj\navMenuItems( LegNav\legName() );
             $modifiedLegNavMenuItems = ppj\markCurrentlySelectedMenuItem($legNavMenuItems);
         ?>
 

--- a/web/app/themes/ppj/partials/mobileNavigation.php
+++ b/web/app/themes/ppj/partials/mobileNavigation.php
@@ -5,13 +5,13 @@ use ppj\LegNav;
 <div class="mobile-nav">
     <div class="mobile-nav__overlay"></div>
     <?php
-    $legNavMenuItems = wp_get_nav_menu_items( LegNav\legName() );
+    $legNavMenuItems = ppj\navMenuItems( LegNav\legName() );
     $modifiedLegNavMenuItems = ppj\markCurrentlySelectedMenuItem($legNavMenuItems);
     $currentLegItem = false;
     $isOnLeg = LegNav\onLeg();
 
     if ($isOnLeg) {
-        $siteWideNavMenuItems = wp_get_nav_menu_items('site-wide-nav');
+        $siteWideNavMenuItems = ppj\navMenuItems('site-wide');
         $modifiedSiteWideNavItems = ppj\markCurrentlySelectedAncestorMenuItem($siteWideNavMenuItems);
 
         foreach ($modifiedSiteWideNavItems as $item) {


### PR DESCRIPTION
The theme now supports three navigation menu locations: 'site-wide', 'prison-officer' and 'youth-custody'.
Menus must be assigned to each menu location in the WordPress CMS. If not assigned, menus on the frontend will appear empty.
A convenience method, `ppj\navMenuItems`, has been added to retrieve menu items for the given menu location.