### PR TITLE
Update ACF field group 'Leg Homepage' to only show on pages

### DIFF
--- a/web/app/mu-plugins/ppj/acf-json/group_5b08050c99245.json
+++ b/web/app/mu-plugins/ppj/acf-json/group_5b08050c99245.json
@@ -83,6 +83,11 @@
                 "param": "current_user_role",
                 "operator": "==",
                 "value": "administrator"
+            },
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "page"
             }
         ]
     ],
@@ -94,5 +99,5 @@
     "hide_on_screen": "",
     "active": 1,
     "description": "",
-    "modified": 1527253254
+    "modified": 1528977088
 }


### PR DESCRIPTION
The ACF field group 'Leg Homepage' will now only show when editing posts of type 'page'. The previous configuration meant that the 'Leg Homepage' fields were showing on the edit screen for other top-level posts, for example when editing 'Safe Redirect Manager' redirect rules, as well as regular posts.