### PR TITLE
Created new GTM job page user interaction events

### DIFF
--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -380,6 +380,10 @@
       },
 
       handleMapMarkerClick(self, locationId, event) {
+        window.dataLayer.push({
+          event: 'map_marker_click',
+          prisonName: locationId
+        });
         self.focusOnSelectedJob(self, locationId);
         self.focusOnLocation(locationId);
         event.preventDefault();
@@ -388,6 +392,10 @@
       },
 
       handleVacancyClick(locationId) {
+        window.dataLayer.push({
+          event: 'job_list_element_click',
+          prisonName: locationId
+        });
         this.focusOnLocation(locationId);
       },
 
@@ -713,7 +721,7 @@
         const locations = {};
 
         for (let i = 0; i < jobs.length; i++) {
-          const locationId = jobs[i].prison_name.replace(/ /g, '-').toLowerCase();
+          const locationId = jobs[i].prison_name;
           jobs[i].locationId = locationId;
 
           if (typeof locations[locationId] == 'undefined') {


### PR DESCRIPTION
The two new events pushed to the datalayer are map_marker_click and job_list_element_click.
These correspond to GTM triggers: Job Map Marker Click and Job List Element Click.
These in turn activate the following tags: Job Map Marker Click and Job List Element Click.

Now using the unmodified prison name as the location id instead of a kebab case version of the prison name.