### PR TITLE
Remove temp directory override

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -84,5 +84,3 @@ if (!defined('ABSPATH')) {
 }
 
 define('WP_DEFAULT_THEME', 'ppj');
-
-define('WP_TEMP_DIR', dirname(__FILE__) . '/wp-content/temp/');


### PR DESCRIPTION
The temp directory was overridden with the constant `WP_TEMP_DIR`, but it was pointing to a non-existent, non-writable directory. By removing this configuration, WordPress will default to using the /tmp directory which is writable.