### PR TITLE
Fix view job bug on chrome

### DIFF
--- a/web/app/themes/ppj/package-lock.json
+++ b/web/app/themes/ppj/package-lock.json
@@ -249,7 +249,7 @@
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha1-O7xCdd1YTMGxCAm4nU6LY6aednU=",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
       "dev": true
     },
     "asn1": {
@@ -311,7 +311,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -1229,15 +1229,15 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "browser-sync": {
-      "version": "2.24.4",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.4.tgz",
-      "integrity": "sha1-5uFUTIpsCI3Hb0n3BZvD35Z+CuA=",
+      "version": "2.24.5",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.5.tgz",
+      "integrity": "sha512-r6ZRYncfYRGerw4Rh5S8Q9x9WKDdrwH572hd3ofsYgn0Px6a6EqXiLBVTCss2+2a45G9ZgjRHSeo9YY56UpgKw==",
       "dev": true,
       "requires": {
         "browser-sync-ui": "1.0.1",
         "bs-recipes": "1.3.4",
         "chokidar": "1.7.0",
-        "connect": "3.5.0",
+        "connect": "3.6.6",
         "connect-history-api-fallback": "1.5.0",
         "dev-ip": "1.0.1",
         "easy-extender": "2.3.2",
@@ -1255,20 +1255,14 @@
         "raw-body": "2.3.2",
         "resp-modifier": "6.0.2",
         "rx": "4.1.0",
-        "serve-index": "1.8.0",
+        "serve-index": "1.9.1",
         "serve-static": "1.13.2",
         "server-destroy": "1.0.1",
-        "socket.io": "2.0.4",
+        "socket.io": "2.1.1",
         "ua-parser-js": "0.7.17",
         "yargs": "6.4.0"
       },
       "dependencies": {
-        "batch": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-          "integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ=",
-          "dev": true
-        },
         "camelcase": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -1280,15 +1274,6 @@
           "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
           "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
           "dev": true
-        },
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
         },
         "depd": {
           "version": "1.1.2",
@@ -1302,17 +1287,6 @@
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
           "dev": true
         },
-        "http-errors": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-          "integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.2",
-            "statuses": "1.3.1"
-          }
-        },
         "http-proxy": {
           "version": "1.15.2",
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
@@ -1322,12 +1296,6 @@
             "eventemitter3": "1.2.0",
             "requires-port": "1.0.0"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         },
         "opn": {
           "version": "4.0.2",
@@ -1358,68 +1326,12 @@
             "escape-html": "1.0.3",
             "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.3",
+            "http-errors": "1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
             "statuses": "1.4.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-              "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "http-errors": {
-              "version": "1.6.3",
-              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-              "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-              "dev": true,
-              "requires": {
-                "depd": "1.1.2",
-                "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": "1.4.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            },
-            "setprototypeof": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-              "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-              "dev": true
-            },
-            "statuses": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-              "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
-              "dev": true
-            }
-          }
-        },
-        "serve-index": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-          "integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
-          "dev": true,
-          "requires": {
-            "accepts": "1.3.4",
-            "batch": "0.5.3",
-            "debug": "2.2.0",
-            "escape-html": "1.0.3",
-            "http-errors": "1.5.1",
-            "mime-types": "2.1.17",
-            "parseurl": "1.3.2"
           }
         },
         "serve-static": {
@@ -1434,10 +1346,10 @@
             "send": "0.16.2"
           }
         },
-        "setprototypeof": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-          "integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg=",
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
           "dev": true
         },
         "window-size": {
@@ -1482,7 +1394,7 @@
     "browser-sync-ui": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
-      "integrity": "sha1-l0BSeybR16ziWazAx55bXjfQ/fI=",
+      "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
       "dev": true,
       "requires": {
         "async-each-series": "0.1.1",
@@ -2089,51 +2001,15 @@
       }
     },
     "connect": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-      "integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
       "dev": true,
       "requires": {
-        "debug": "2.2.0",
-        "finalhandler": "0.5.0",
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
         "parseurl": "1.3.2",
-        "utils-merge": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "finalhandler": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-          "integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
-          "dev": true,
-          "requires": {
-            "debug": "2.2.0",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "statuses": "1.3.1",
-            "unpipe": "1.0.0"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "utils-merge": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-          "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
-          "dev": true
-        }
+        "utils-merge": "1.0.1"
       }
     },
     "connect-history-api-fallback": {
@@ -2283,12 +2159,31 @@
       }
     },
     "cross-env": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.1.6.tgz",
-      "integrity": "sha512-VWTDq+G4v383SzgRS7jsAVWqEWF0aKZpDz1GVjhONvPRgHB1LnxP2sXUVFKbykHkPSnfRKS8YdiDevWFwZmQ9g==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
       "requires": {
-        "cross-spawn": "5.1.0",
+        "cross-spawn": "6.0.5",
         "is-windows": "1.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+        }
       }
     },
     "cross-spawn": {
@@ -3073,9 +2968,9 @@
       }
     },
     "engine.io": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
-      "integrity": "sha1-Dn751pDrCzVZfx1K0Comyi26OEU=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
@@ -3083,7 +2978,6 @@
         "cookie": "0.3.1",
         "debug": "3.1.0",
         "engine.io-parser": "2.1.2",
-        "uws": "9.14.0",
         "ws": "3.3.3"
       },
       "dependencies": {
@@ -3101,7 +2995,7 @@
     "engine.io-client": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-      "integrity": "sha1-W96xMPi5SlCsXL63JYPnpKBj3f0=",
+      "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -3131,7 +3025,7 @@
     "engine.io-parser": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-      "integrity": "sha1-TA9M/3mq7su9z96maoI8YIVAkZY=",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
       "dev": true,
       "requires": {
         "after": "0.8.2",
@@ -5020,7 +4914,7 @@
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-      "integrity": "sha1-d3asYn8+p3JQz8My2rfd9eT10R0=",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
       "dev": true,
       "requires": {
         "isarray": "2.0.1"
@@ -5624,7 +5518,7 @@
     "is-number-like": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-      "integrity": "sha1-LhKWILUIkQQuROm7uzBZPnXPu+M=",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
       "dev": true,
       "requires": {
         "lodash.isfinite": "3.3.2"
@@ -6031,7 +5925,7 @@
     "limiter": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-      "integrity": "sha1-MuLrVbIyQHaUPl0EwRhf+zh5aO8=",
+      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==",
       "dev": true
     },
     "load-json-file": {
@@ -6071,7 +5965,7 @@
     "localtunnel": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
-      "integrity": "sha1-j/7Nz4yKFPYt8QVs+dVKy7C7mo8=",
+      "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
       "dev": true,
       "requires": {
         "axios": "0.17.1",
@@ -6802,6 +6696,11 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
     },
     "no-case": {
       "version": "2.3.2",
@@ -14386,16 +14285,86 @@
       }
     },
     "socket.io": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
-      "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "engine.io": "3.1.5",
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
         "socket.io-adapter": "1.1.1",
-        "socket.io-client": "2.0.4",
-        "socket.io-parser": "3.1.3"
+        "socket.io-client": "2.1.1",
+        "socket.io-parser": "3.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "engine.io-client": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+          "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
+            "yeast": "0.1.2"
+          }
+        },
+        "isarray": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
+        },
+        "socket.io-client": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+          "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+          "dev": true,
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "3.1.0",
+            "engine.io-client": "3.2.1",
+            "has-binary2": "1.0.3",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "3.2.0",
+            "to-array": "0.1.4"
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+          "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+          "dev": true,
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "3.1.0",
+            "isarray": "2.0.1"
+          }
+        }
       }
     },
     "socket.io-adapter": {
@@ -14428,7 +14397,7 @@
     "socket.io-parser": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-      "integrity": "sha1-7S2l7nnxCVUDbj2kE7/X8eTYbI4=",
+      "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
       "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
@@ -15185,7 +15154,7 @@
     "ua-parser-js": {
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-      "integrity": "sha1-6exflJi57JEOeuOsYmqAXE0J7Kw=",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
     },
     "uglify-js": {
@@ -15257,7 +15226,7 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
     "uniq": {
@@ -15410,13 +15379,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "uws": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
-      "integrity": "sha1-+sg4a+/DOno3BcvVjcR7Qwyk3ZU=",
-      "dev": true,
-      "optional": true
     },
     "vali-date": {
       "version": "1.0.0",
@@ -15861,7 +15823,7 @@
     "ws": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha1-8c+E/i1ekB686U767OeF8YeiKPI=",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "dev": true,
       "requires": {
         "async-limiter": "1.0.0",

--- a/web/app/themes/ppj/package.json
+++ b/web/app/themes/ppj/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "axios": "^0.17.1",
-    "cross-env": "^5.1.6",
+    "cross-env": "^5.2.0",
     "debounce": "^1.1.0",
     "details-element-polyfill": "^2.0.1",
     "jquery": "^3.3.1",
@@ -20,7 +20,7 @@
     "vue-template-compiler": "^2.5.16"
   },
   "devDependencies": {
-    "browser-sync": "^2.24.4",
+    "browser-sync": "^2.24.5",
     "browser-sync-webpack-plugin": "^1.2.0"
   },
   "scripts": {

--- a/web/app/themes/ppj/src/vue/JobSummary.vue
+++ b/web/app/themes/ppj/src/vue/JobSummary.vue
@@ -45,6 +45,24 @@
           prisonName: this.prisonName
         };
         window.dataLayer.push(gtmEvent);
+
+        /*
+         * NB: This is fix for the issue whereby clicking the 'View Job & Apply' link
+         * in Chrome did not navigate to the location specified by the href attribute
+         *
+         * This is probably due to a race condition caused by some combination of
+         * the linked to site responding slowly and the triggered history.replaceState action
+         * happening asynchronously.
+         *
+         * By adding the following timeout function to explicitly navigate to the supplied url,
+         * the correct navigation happens, despite the fact that the timeout is set to happen
+         * zero milliseconds later. Presumably in a single threaded environment, the earliest
+         * this function gets executed is after the replaceState operation.
+         *
+         * This went unnoticed for a while due to Google Tag Manager presumably slowing
+         * some part of the execution sufficiently such that this race condition didn't exist.
+         */
+        setTimeout(()=>{window.location.href = this.url;}, 0);
       }
     },
 


### PR DESCRIPTION
NB: This is fix for the issue whereby clicking the 'View Job & Apply' link on the Find A Job page in Chrome did not navigate to the location specified by the href attribute.
         
This is probably due to a race condition caused by some combination of the linked to site responding slowly and the triggered history.replaceState action happening asynchronously.
         
By adding the following timeout function to explicitly navigate to the supplied url, the correct navigation happens, despite the fact that the timeout is set to happen zero milliseconds later. Presumably in a single threaded environment, the earliest this function gets executed is after the replaceState operation.
         
This went unnoticed for a while due to Google Tag Manager presumably slowing some part of the execution sufficiently such that this race condition didn't exist.