### PR TITLE
Fix "Missing a temporary folder" bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM mojdigital/wordpress-base:latest
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /init
+    rm -rf /var/lib/apt/lists/* /var/tmp/* /init
 
 ADD . /bedrock
 


### PR DESCRIPTION
This should solve the issue we've been seeing where WordPress complains that it doesn't have a temporary directory to write to.

WordPress uses the local directory `/tmp` for temporary files, such as when uploading & resizing images in the Media Library.

However, I have observed an issue where one of the components of this image (`yas3fs`) erroneously deletes the entire `/tmp` directory. Therefore WordPress displays the error message "Missing a temporary folder" because it no longer has a writable directory for temporary files.

The base WordPress docker image ([`mojdigital/wordpress-base`](https://hub.docker.com/r/mojdigital/wordpress-base/)) includes [a workaround](https://github.com/ministryofjustice/wordpress-base-docker/blob/0a351f528e8e701d5f4ea2b6432076e2f04b4b39/Dockerfile#L112) to stop `yas3fs` from deleting the `/tmp` directory. However the `Dockerfile` for this image removes that workaround.

This Pull Request changes the `Dockerfile` so that the `yas3fs` workaround provided by the WordPress base image is no longer removed.