### PR TITLE
Add focus styles to links and interactive elements

### DIFF
--- a/web/app/themes/ppj/src/sass/main.sass
+++ b/web/app/themes/ppj/src/sass/main.sass
@@ -71,11 +71,6 @@ body,
 html
   min-height: 100%
 
-*
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0)
-  -moz-tap-highlight-color: rgba(0, 0, 0, 0)
-
-
 h1,h2,h3,h4,h5,h6,
 p
   margin: 0 0 .65em 0
@@ -91,9 +86,6 @@ img
 // http://vuetips.com/v-cloak-directive-hides-html-on-startup
 html
   opacity: 0
-
-*:focus
-  outline: none
 
 a[href=""]
   pointer-events: none

--- a/web/app/themes/ppj/src/sass/utilities/_cta-link.sass
+++ b/web/app/themes/ppj/src/sass/utilities/_cta-link.sass
@@ -1,6 +1,8 @@
 .cta-link
+  $box-shadow: 0 0 0 .3rem $color-white
+
   border-radius: 5rem
-  box-shadow: 0 0 0 .3rem $color-white;
+  box-shadow: $box-shadow
   color: $color-white
   display: inline-block
   font-size: 1.6rem
@@ -12,6 +14,10 @@
   text-decoration: none
   text-transform: uppercase
   z-index: 1
+
+  &:focus
+    outline: 0
+    box-shadow: $box-shadow, 0 0 0 .6rem Highlight
 
   @include bp('portrait')
     font-size: 2rem


### PR DESCRIPTION
- Re-enable browser default focus outline styles. These had previously been disabled.
- Add custom focus styles to `.cta-link` elements. This involves disabling the default outline style, and replacing it with a box-shadow – this means the focus ring will follow the border radius style which applies to these elements.