### PR TITLE
<img> elements now replaced by background images on ie11

### DIFF
--- a/web/app/themes/ppj/partials/headerHeroImage.php
+++ b/web/app/themes/ppj/partials/headerHeroImage.php
@@ -75,7 +75,9 @@ if ( $headerImageData ) {
 }
 ?>
 
-<div class="header__img-container">
+<div class="header__img-container"
+     data-ie-bg-img="url('<?= $headerImageUrl ?>')"
+>
     <img class="header__image"
          src="<?= $headerImageUrl ?>"
          srcset="<?= $srcset ?>"

--- a/web/app/themes/ppj/partials/headerHeroImage.php
+++ b/web/app/themes/ppj/partials/headerHeroImage.php
@@ -76,7 +76,7 @@ if ( $headerImageData ) {
 ?>
 
 <div class="header__img-container"
-     data-bg-img-url="url('<?= $headerImageUrl ?>')"
+     data-bg-img-url="<?= esc_attr($headerImageUrl) ?>"
 >
     <img class="header__image"
          src="<?= $headerImageUrl ?>"

--- a/web/app/themes/ppj/partials/headerHeroImage.php
+++ b/web/app/themes/ppj/partials/headerHeroImage.php
@@ -76,7 +76,7 @@ if ( $headerImageData ) {
 ?>
 
 <div class="header__img-container"
-     data-ie-bg-img="url('<?= $headerImageUrl ?>')"
+     data-bg-img-url="url('<?= $headerImageUrl ?>')"
 >
     <img class="header__image"
          src="<?= $headerImageUrl ?>"

--- a/web/app/themes/ppj/partials/landingPage.php
+++ b/web/app/themes/ppj/partials/landingPage.php
@@ -36,7 +36,7 @@ $td = $ppj_template_data;
                                             <div class="landing-page-groups__card-image-ratio">
                                                 <a href="<?= $cardLinkUrl ?>"
                                                    class="landing-page-groups__card-link"
-                                                   data-ie-bg-img="<?= $bgImgUrl ?>"
+                                                   data-bg-img-url="<?= $bgImgUrl ?>"
                                                 >
 
                                                     <?php echo wp_get_attachment_image(

--- a/web/app/themes/ppj/partials/landingPage.php
+++ b/web/app/themes/ppj/partials/landingPage.php
@@ -27,7 +27,7 @@ $td = $ppj_template_data;
                             $cardLinkUrl = (isset($card['link']['url'])) ? $card['link']['url'] : '';
 
                             $cardImg = wp_get_attachment_image_src($card['image']['id'], $size = 'header-portrait-home');
-                            $bgImgUrl = ($cardImg) ? "url('{$cardImg[0]}')" : '';
+                            $bgImgUrl = ($cardImg) ? $cardImg[0] : '';
                             ?>
                             <div class="<?= $cardClasses ?>">
                                 <?php if($cardHasImage): ?>
@@ -36,7 +36,7 @@ $td = $ppj_template_data;
                                             <div class="landing-page-groups__card-image-ratio">
                                                 <a href="<?= $cardLinkUrl ?>"
                                                    class="landing-page-groups__card-link"
-                                                   data-bg-img-url="<?= $bgImgUrl ?>"
+                                                   data-bg-img-url="<?= esc_attr($bgImgUrl) ?>"
                                                 >
 
                                                     <?php echo wp_get_attachment_image(

--- a/web/app/themes/ppj/partials/landingPage.php
+++ b/web/app/themes/ppj/partials/landingPage.php
@@ -25,14 +25,19 @@ $td = $ppj_template_data;
                             $cardClasses .= ($cardHasImage)  ? ' ' . $cardClass . '--has-image'               : '';
 
                             $cardLinkUrl = (isset($card['link']['url'])) ? $card['link']['url'] : '';
+
+                            $cardImg = wp_get_attachment_image_src($card['image']['id'], $size = 'header-portrait-home');
+                            $bgImgUrl = ($cardImg) ? "url('{$cardImg[0]}')" : '';
                             ?>
                             <div class="<?= $cardClasses ?>">
                                 <?php if($cardHasImage): ?>
                                     <div class="landing-page-groups__card-image-container">
                                         <div class="landing-page-groups__card-image-ratio-container">
                                             <div class="landing-page-groups__card-image-ratio">
-
-                                                <a href="<?= $cardLinkUrl ?>">
+                                                <a href="<?= $cardLinkUrl ?>"
+                                                   class="landing-page-groups__card-link"
+                                                   data-ie-bg-img="<?= $bgImgUrl ?>"
+                                                >
 
                                                     <?php echo wp_get_attachment_image(
                                                         $card['image']['id'],

--- a/web/app/themes/ppj/partials/videoPlayer.php
+++ b/web/app/themes/ppj/partials/videoPlayer.php
@@ -2,24 +2,31 @@
 
 global $ppj_template_data;
 $td = $ppj_template_data;
-$coverImage = wp_get_attachment_image(
-    $td['cover-image-id'],
-    'large',
-    false,
-    [
-        'class' => 'video-player__cover-image',
-        'sizes' => '(min-width: 1440px) 792px, (min-width: 1024px) 915px, (max-width: 768px) calc((100vw - 64px) * 0.75), 0.85vw'
-    ]
-);
-$coverImageURL = wp_get_attachment_image_url($td['cover-image-id'], 'large');
 
 ?>
 
 <div class="video-player video-player--<?= $td['host'] ?>"
      id="<?= $td['id'] ?>"
 >
-    <?php if ($td['cover-image-id']): ?>
-        <a href="#" class="video-player__cover" aria-label="Play Video" data-bg-img-url="url('<?= $coverImageURL ?>')">
+    <?php if ($td['cover-image-id']):
+
+        $coverImage = wp_get_attachment_image(
+            $td['cover-image-id'],
+            'large',
+            false,
+            [
+                'class' => 'video-player__cover-image',
+                'sizes' => '(min-width: 1440px) 792px, (min-width: 1024px) 915px, (max-width: 768px) calc((100vw - 64px) * 0.75), 0.85vw'
+            ]
+        );
+        $coverImageURL = wp_get_attachment_image_url($td['cover-image-id'], 'large');
+
+        ?>
+        <a aria-label="Play Video"
+           class="video-player__cover"
+           data-bg-img-url="<?= esc_attr($coverImageURL) ?>"
+           href="#"
+        >
             <?php echo $coverImage ?>
             <div class="video-player__play-button-container">
                 <svg class="video-player__play-button"

--- a/web/app/themes/ppj/partials/videoPlayer.php
+++ b/web/app/themes/ppj/partials/videoPlayer.php
@@ -9,7 +9,7 @@ $td = $ppj_template_data;
      id="<?= $td['id'] ?>"
 >
     <?php if ($td['cover-image-id']): ?>
-        <a href="#" class="video-player__cover" aria-label="Play Video">
+        <a href="#" class="video-player__cover" aria-label="Play Video" data-ie-bg-img="url('<?= $td['cover-image'] ?>')">
             <?php
 
             echo wp_get_attachment_image(
@@ -19,6 +19,7 @@ $td = $ppj_template_data;
                 ]);
 
             ?>
+
             <div class="video-player__play-button-container">
                 <svg class="video-player__play-button"
                      x="0px"

--- a/web/app/themes/ppj/partials/videoPlayer.php
+++ b/web/app/themes/ppj/partials/videoPlayer.php
@@ -2,6 +2,16 @@
 
 global $ppj_template_data;
 $td = $ppj_template_data;
+$coverImage = wp_get_attachment_image(
+    $td['cover-image-id'],
+    'large',
+    false,
+    [
+        'class' => 'video-player__cover-image',
+        'sizes' => '(min-width: 1440px) 792px, (min-width: 1024px) 915px, (max-width: 768px) calc((100vw - 64px) * 0.75), 0.85vw'
+    ]
+);
+$coverImageURL = wp_get_attachment_image_url($td['cover-image-id'], 'large');
 
 ?>
 
@@ -9,17 +19,8 @@ $td = $ppj_template_data;
      id="<?= $td['id'] ?>"
 >
     <?php if ($td['cover-image-id']): ?>
-        <a href="#" class="video-player__cover" aria-label="Play Video" data-ie-bg-img="url('<?= $td['cover-image'] ?>')">
-            <?php
-
-            echo wp_get_attachment_image(
-                $td['cover-image-id'], 'large', false, [
-                    'class' => 'video-player__cover-image',
-                    'sizes' => '(min-width: 1440px) 792px, (min-width: 1024px) 915px, (max-width: 768px) calc((100vw - 64px) * 0.75), 0.85vw'
-                ]);
-
-            ?>
-
+        <a href="#" class="video-player__cover" aria-label="Play Video" data-bg-img-url="url('<?= $coverImageURL ?>')">
+            <?php echo $coverImage ?>
             <div class="video-player__play-button-container">
                 <svg class="video-player__play-button"
                      x="0px"
@@ -55,7 +56,3 @@ $td = $ppj_template_data;
          <?php endif; ?>
    </div>
 </div>
-
-<script>
-
-</script>

--- a/web/app/themes/ppj/src/js/main.js
+++ b/web/app/themes/ppj/src/js/main.js
@@ -2,14 +2,31 @@ import 'details-element-polyfill';
 import scrollpoints from 'scrollpoints';
 import closestPolyfill from './polyfills/Element.closest';
 
-// set background images based on data-bg-img-url attributes for ie11
-var isIE = /*@cc_on!@*/false || !!document.documentMode;
-if (isIE) {
-  var imgElements = document.querySelectorAll('[data-ie-bg-img]');
-  for(var i = 0; i < imgElements.length; i++) {
-    imgElements[i].style.backgroundImage = imgElements[i].getAttribute('data-ie-bg-img');
+/**
+ * If object-fit is not supported (eg on IE 11), we cannot use <img> tags
+ * as the image being used is not guaranteed to be of the same ratio as its container
+ * which would lead to a distorted image being presented to the user.
+ *
+ * Instead a background image will be set on the <img> container
+ * and the background image will have `background-size set` to cover,
+ * and the existing <img> will be set to `display: none` in CSS.
+ *
+ * The URL of the background image to be used is stored in the
+ * data attribute `data-bg-img-url` on the <img> container.
+ */
+function addObjectFitNotSupportedClassToBody() {
+  if (typeof document.querySelector('img').style.objectFit == 'undefined') {
+    console.log('object fit not supported');
+    document.querySelector('body').classList.add('object-fit-not-supported');
+    var imgElements = document.querySelectorAll('[data-bg-img-url]');
+    for(var i = 0; i < imgElements.length; i++) {
+      imgElements[i].style.backgroundImage = imgElements[i].getAttribute('data-bg-img-url');
+    }
+  } else {
+    console.log('object fit supported');
   }
 }
+addObjectFitNotSupportedClassToBody();
 
 closestPolyfill();
 
@@ -153,3 +170,4 @@ nonMobiles.addListener(setAriaHiddenForNonVisibleSiteWideNavLinks);
 
 // Set ARIA hidden attributes for site-wide-nav links on page load
 setAriaHiddenForNonVisibleSiteWideNavLinks(nonMobiles);
+

--- a/web/app/themes/ppj/src/js/main.js
+++ b/web/app/themes/ppj/src/js/main.js
@@ -2,6 +2,15 @@ import 'details-element-polyfill';
 import scrollpoints from 'scrollpoints';
 import closestPolyfill from './polyfills/Element.closest';
 
+// set background images based on data-bg-img-url attributes for ie11
+var isIE = /*@cc_on!@*/false || !!document.documentMode;
+if (isIE) {
+  var imgElements = document.querySelectorAll('[data-ie-bg-img]');
+  for(var i = 0; i < imgElements.length; i++) {
+    imgElements[i].style.backgroundImage = imgElements[i].getAttribute('data-ie-bg-img');
+  }
+}
+
 closestPolyfill();
 
 if ('dataLayer' in window == false) {
@@ -144,4 +153,3 @@ nonMobiles.addListener(setAriaHiddenForNonVisibleSiteWideNavLinks);
 
 // Set ARIA hidden attributes for site-wide-nav links on page load
 setAriaHiddenForNonVisibleSiteWideNavLinks(nonMobiles);
-

--- a/web/app/themes/ppj/src/js/main.js
+++ b/web/app/themes/ppj/src/js/main.js
@@ -1,32 +1,9 @@
 import 'details-element-polyfill';
 import scrollpoints from 'scrollpoints';
 import closestPolyfill from './polyfills/Element.closest';
+import objectFitPolyfill from './polyfills/objectFit';
 
-/**
- * If object-fit is not supported (eg on IE 11), we cannot use <img> tags
- * as the image being used is not guaranteed to be of the same ratio as its container
- * which would lead to a distorted image being presented to the user.
- *
- * Instead a background image will be set on the <img> container
- * and the background image will have `background-size set` to cover,
- * and the existing <img> will be set to `display: none` in CSS.
- *
- * The URL of the background image to be used is stored in the
- * data attribute `data-bg-img-url` on the <img> container.
- */
-function addObjectFitNotSupportedClassToBody() {
-  if (typeof document.querySelector('img').style.objectFit == 'undefined') {
-    console.log('object fit not supported');
-    document.querySelector('body').classList.add('object-fit-not-supported');
-    var imgElements = document.querySelectorAll('[data-bg-img-url]');
-    for(var i = 0; i < imgElements.length; i++) {
-      imgElements[i].style.backgroundImage = imgElements[i].getAttribute('data-bg-img-url');
-    }
-  } else {
-    console.log('object fit supported');
-  }
-}
-addObjectFitNotSupportedClassToBody();
+objectFitPolyfill();
 
 closestPolyfill();
 

--- a/web/app/themes/ppj/src/js/polyfills/objectFit.js
+++ b/web/app/themes/ppj/src/js/polyfills/objectFit.js
@@ -1,0 +1,21 @@
+/**
+ * If object-fit is not supported (eg on IE 11), we cannot use <img> tags
+ * as the image being used is not guaranteed to be of the same ratio as its container
+ * which would lead to a distorted image being presented to the user.
+ *
+ * Instead a background image will be set on the <img> container
+ * and the background image will have `background-size set` to cover,
+ * and the existing <img> will be set to `display: none` in CSS.
+ *
+ * The URL of the background image to be used is stored in the
+ * data attribute `data-bg-img-url` on the <img> container.
+ */
+export default function() {
+  if (typeof document.querySelector('img').style.objectFit == 'undefined') {
+    document.querySelector('body').classList.add('object-fit-not-supported');
+    var imgElements = document.querySelectorAll('[data-bg-img-url]');
+    for(var i = 0; i < imgElements.length; i++) {
+      imgElements[i].style.backgroundImage = "url('" + imgElements[i].getAttribute('data-bg-img-url') + "')";
+    }
+  }
+};

--- a/web/app/themes/ppj/src/sass/components/header.sass
+++ b/web/app/themes/ppj/src/sass/components/header.sass
@@ -79,6 +79,9 @@
     transition: $main-transition-duration
     width: 100%
 
+    @include ie11
+      display: none
+
     &--loaded
       opacity: 1
 
@@ -96,6 +99,7 @@
 
   &__img-container
     background-color: $color-dark
+    background-image: none
     background-position: center center
     background-size: cover
     bottom: 0
@@ -103,6 +107,9 @@
     position: absolute
     right: 0
     top: 0
+
+    @include ie11
+      background-size: cover
 
     &:before
       background: linear-gradient(to bottom, $color-transparency-dark-start, $color-transparent)

--- a/web/app/themes/ppj/src/sass/components/header.sass
+++ b/web/app/themes/ppj/src/sass/components/header.sass
@@ -79,9 +79,6 @@
     transition: $main-transition-duration
     width: 100%
 
-    @include ie11
-      display: none
-
     &--loaded
       opacity: 1
 
@@ -107,9 +104,6 @@
     position: absolute
     right: 0
     top: 0
-
-    @include ie11
-      background-size: cover
 
     &:before
       background: linear-gradient(to bottom, $color-transparency-dark-start, $color-transparent)

--- a/web/app/themes/ppj/src/sass/landing-page.sass
+++ b/web/app/themes/ppj/src/sass/landing-page.sass
@@ -173,6 +173,11 @@ $color-tertiary: $color-dark
       right: 0
       top: 0
 
+    &-link
+      display: block
+      height: 100%
+      width: 100%
+
     &-image
       height: 100%
       width: 100%

--- a/web/app/themes/ppj/src/sass/main.sass
+++ b/web/app/themes/ppj/src/sass/main.sass
@@ -9,7 +9,6 @@
 @import '404'
 
 @import 'utilities/top-border'
-@import 'utilities/browser-specific'
 @import 'utilities/clearfix'
 @import 'utilities/common-header'
 @import 'utilities/common-table'
@@ -93,12 +92,11 @@ p
 img
   object-fit: cover
 
-[data-ie-bg-img]
+.object-fit-not-supported [data-bg-img-url]
   background-size: cover
 
-  @include ie11
-    img
-      display: none
+  img
+    display: none
 
 // TODO use this instead :
 // http://vuetips.com/v-cloak-directive-hides-html-on-startup

--- a/web/app/themes/ppj/src/sass/main.sass
+++ b/web/app/themes/ppj/src/sass/main.sass
@@ -8,6 +8,17 @@
 @import 'layout'
 @import '404'
 
+@import 'utilities/top-border'
+@import 'utilities/browser-specific'
+@import 'utilities/clearfix'
+@import 'utilities/common-header'
+@import 'utilities/common-table'
+@import 'utilities/cta-link'
+@import 'utilities/embed'
+@import 'utilities/grid'
+@import 'utilities/margin'
+@import 'utilities/wire-frame'
+
 // base reset
 button
   background: none
@@ -82,6 +93,13 @@ p
 img
   object-fit: cover
 
+[data-ie-bg-img]
+  background-size: cover
+
+  @include ie11
+    img
+      display: none
+
 // TODO use this instead :
 // http://vuetips.com/v-cloak-directive-hides-html-on-startup
 html
@@ -124,18 +142,6 @@ p a
 hr
   border-top: .1rem solid $color-light
   margin: $common-spacing 0
-
-// utilities
-
-@import 'utilities/clearfix'
-@import 'utilities/top-border'
-@import 'utilities/common-header'
-@import 'utilities/common-table'
-@import 'utilities/cta-link'
-@import 'utilities/embed'
-@import 'utilities/grid'
-@import 'utilities/margin'
-@import 'utilities/wire-frame'
 
 
 // -- COMPONENTS ------------------------------------------

--- a/web/app/themes/ppj/src/sass/utilities/_browser-specific.sass
+++ b/web/app/themes/ppj/src/sass/utilities/_browser-specific.sass
@@ -1,0 +1,3 @@
+@mixin ie11
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active)
+    @content

--- a/web/app/themes/ppj/src/sass/utilities/_browser-specific.sass
+++ b/web/app/themes/ppj/src/sass/utilities/_browser-specific.sass
@@ -1,3 +1,0 @@
-@mixin ie11
-  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active)
-    @content


### PR DESCRIPTION
As this is a responsive site, the images need to resize properly.
Unfortunately ie11 does not support the object-fit property which would facilitate this.
Therefore on ie11 <img> tags are replaced with a background img on the parent element
as ie11 does support `background-size: cover` css rule.

However the parent element cannot have the `background-image` set upon
loading as this would mean every browser, not just ie, would download
a background image. Therefore the value for the background image
is stored in a data attribute `data-ie-bg-img`.
Javascript can then be used to detect if the current browser is ie11;
if so then the the value within `data-ie-bg-img` is set as
the background-image value.

A utility mixin was created to implement browser specific css;
so far only Internet Explorer 11 is supported.