### PR TITLE
Video player accessibility

### DIFF
--- a/web/app/mu-plugins/ppj/ppj-functions.php
+++ b/web/app/mu-plugins/ppj/ppj-functions.php
@@ -147,7 +147,7 @@ function videoPlayer($attrs)
     $a = shortcode_atts(array(
         'host' => 'youtube',
         'id' => '',
-        'cover-image' => ''
+        'cover-image-id' => null,
     ), $attrs);
 
     return partial($a, 'videoPlayer');

--- a/web/app/themes/ppj/partials/videoPlayer.php
+++ b/web/app/themes/ppj/partials/videoPlayer.php
@@ -8,17 +8,24 @@ $td = $ppj_template_data;
 <div class="video-player video-player--<?= $td['host'] ?>"
      id="<?= $td['id'] ?>"
 >
-    <?php if (isset($td['cover-image']) && $td['cover-image']): ?>
-        <a href="#" class="video-player__cover">
-            <img src="<?= $td['cover-image'] ?>"
-                 class="video-player__cover-image"
-            />
+    <?php if ($td['cover-image-id']): ?>
+        <a href="#" class="video-player__cover" aria-label="Play Video">
+            <?php
+
+            echo wp_get_attachment_image(
+                $td['cover-image-id'], 'large', false, [
+                    'class' => 'video-player__cover-image',
+                    'sizes' => '(min-width: 1440px) 792px, (min-width: 1024px) 915px, (max-width: 768px) calc((100vw - 64px) * 0.75), 0.85vw'
+                ]);
+
+            ?>
             <div class="video-player__play-button-container">
                 <svg class="video-player__play-button"
                      x="0px"
                      y="0px"
                      viewBox="0 0 138.3 138.3"
                      style="enable-background:new 0 0 138.3 138.3;"
+                     role="img"
                 >
                     <path class="st0" d="M69.2,8c33.7,0,61.2,27.4,61.2,61.2s-27.4,61.2-61.2,61.2S8,102.9,8,69.2S35.4,8,69.2,8 M69.2,0
                 C31,0,0,31,0,69.2s31,69.2,69.2,69.2s69.2-31,69.2-69.2S107.4,0,69.2,0L69.2,0z"/>

--- a/web/app/themes/ppj/partials/videoPlayer.php
+++ b/web/app/themes/ppj/partials/videoPlayer.php
@@ -9,7 +9,7 @@ $td = $ppj_template_data;
      id="<?= $td['id'] ?>"
 >
     <?php if (isset($td['cover-image']) && $td['cover-image']): ?>
-        <div class="video-player__cover">
+        <a href="#" class="video-player__cover">
             <img src="<?= $td['cover-image'] ?>"
                  class="video-player__cover-image"
             />
@@ -25,7 +25,7 @@ $td = $ppj_template_data;
                     <polygon class="st0" points="96.3,69.2 48.4,41.5 48.4,96.8 96.3,69.2 48.4,41.5 48.4,96.8 	"/>
                 </svg>
             </div>
-        </div>
+        </a>
     <?php endif; ?>
      <div class="video-player__video-container">
          <?php if ($td['host'] == 'wistia'): ?>

--- a/web/app/themes/ppj/src/js/main.js
+++ b/web/app/themes/ppj/src/js/main.js
@@ -49,8 +49,11 @@ window._wq = window._wq || [];
 _wq.push({ id: '_all', onReady: function(video) {
   const videoPlayer = video.container.closest('.video-player');
   const cover = videoPlayer.querySelector('.video-player__cover');
-  video.container.hidden = true;
 
+  // If this video doesn't have a cover image, do nothing
+  if (cover == null) return;
+
+  video.container.hidden = true;
   cover.addEventListener('click', function(event) {
     event.preventDefault();
     video.container.hidden = false;

--- a/web/app/themes/ppj/src/js/main.js
+++ b/web/app/themes/ppj/src/js/main.js
@@ -48,12 +48,17 @@ window._wq = window._wq || [];
 //add callbacks to video play button for all Wistia videos
 _wq.push({ id: '_all', onReady: function(video) {
   const videoPlayer = video.container.closest('.video-player');
+  const cover = videoPlayer.querySelector('.video-player__cover');
+  video.container.hidden = true;
 
-  videoPlayer.querySelector('.video-player__play-button')
-    .addEventListener('click', function(){
-      videoPlayer.classList.add('video-player--playing');
-      video.play();
-    });
+  cover.addEventListener('click', function(event) {
+    event.preventDefault();
+    video.container.hidden = false;
+    cover.hidden = true;
+    video.container.focus();
+    videoPlayer.classList.add('video-player--playing');
+    video.play();
+  });
 }});
 
 window.addEventListener('load', function() {

--- a/web/app/themes/ppj/src/sass/components/video-player.sass
+++ b/web/app/themes/ppj/src/sass/components/video-player.sass
@@ -34,6 +34,10 @@
   &__cover
     z-index: 1
 
+    &:hover #{$vp}__play-button,
+    &:focus #{$vp}__play-button
+      width: 22%
+
   &__cover-image
     height: 100%
     width: 100%
@@ -53,13 +57,6 @@
     fill: $color-white
     transition: $main-transition-duration
     width: 20%
-
-    &:hover
-      width: 22%
-
-  &--playing
-    #{$vp}__cover
-      z-index: -1
 
   &--wistia
     padding-bottom: 0
@@ -82,5 +79,3 @@
     .video-player
       &__video-container
         height: 100%
-
-  &--playing


### PR DESCRIPTION
This PR allows the video cover play button to be focussed and activated with the keyboard.

It also enables alt text and responsive images on the cover overlay image.

Changes to `[video-player]` shortcode attributes:

- Attribute `cover-image` has been removed
- Attribute `cover-image-id` has been introduced, which should be the media library attachment ID of the image to be used