### PR TITLE
Adding a Job Alert Message (JAM) to find-a-job page

### DIFF
--- a/web/app/themes/ppj/find-a-job.php
+++ b/web/app/themes/ppj/find-a-job.php
@@ -5,13 +5,66 @@
 
 include 'page-header.php';
 
+$jobTitle = get_field('job_title');
+$leg = ppj\LegNav\legName();
+$jobAlertHTML = '';
+
+/**
+ * The Job Alert is some bespoke functionality that was commissioned so that during a period of time
+ * (at the time of writing 1st - 15th of October)
+ * when there will be significantly reduced jobs available on the site,
+ * users who visit the 'find a job' page will have the opportunity to supply their email address
+ * such that they can be contacted at a point in the future
+ * when there are more jobs available.
+ */
+
+// If the job alert is active and the activate date has been set, continue.
+// Otherwise do not try to display the job alert.
+if ( (bool)get_field('job_alert_active') && $activateDateString = get_field('job_alert_activate_date')) {
+
+    // Explicitly set the time zone.
+    // This will account for daylight savings.
+    $timeZone = new DateTimeZone('Europe/London');
+
+    // Get the current time as a DateTime object
+    $now = new DateTime('now', $timeZone);
+
+    // Create a DateTime object for when the Job Alert should be activated
+    $activateDate = DateTime::createFromFormat('Y-m-d H:i:s', $activateDateString, $timeZone);
+
+    // Compare the activate date to now, to determine if the JobAlert period has started
+    if ($now->getTimestamp() > $activateDate->getTimestamp()) {
+
+        // If the deactivate date has been set,
+        // calculate if the Job Alert period has already ended
+        // If it hasn't been set then assume the Job Alert period is active now.
+        $ended = false;
+
+        if ($deactivateDateString = get_field('job_alert_deactivate_date') ) {
+            $deactivateDate = DateTime::createFromFormat('Y-m-d H:i:s', $deactivateDateString, $timeZone);
+            $ended          = $now->getTimestamp() > $deactivateDate->getTimestamp();
+        }
+
+        if ( ! $ended ) {
+            $jobAlertHTML = get_field('job_alert_text');
+        }
+    }
+}
+
 ?>
 
 <div class="find-a-job-container">
-    <find-a-job
-        job-title="<?= get_field('job_title') ?>"
-        leg="<?= ppj\LegNav\legName()?>"
-    ></find-a-job>
+
+    <find-a-job job-title="<?= $jobTitle ?>" leg="<?= $leg ?>" >
+
+        <?php if ($jobAlertHTML): ?>
+
+            <template slot="jobAlertHTML"><?= $jobAlertHTML ?></template>
+
+        <?php endif; ?>
+
+    </find-a-job>
+
 </div>
 
 <?php include 'page-footer.php' ?>

--- a/web/app/themes/ppj/find-a-job.php
+++ b/web/app/themes/ppj/find-a-job.php
@@ -20,8 +20,7 @@ $jobAlertHTML = '';
 
 // If the job alert is active and the activate date has been set, continue.
 // Otherwise do not try to display the job alert.
-if ( (bool)get_field('job_alert_active') && $activateDateString = get_field('job_alert_activate_date')) {
-
+if ((bool)get_field('job_alert_active') && $activateDateString = get_field('job_alert_activate_date')) {
     // Explicitly set the time zone.
     // This will account for daylight savings.
     $timeZone = new DateTimeZone('Europe/London');
@@ -34,18 +33,17 @@ if ( (bool)get_field('job_alert_active') && $activateDateString = get_field('job
 
     // Compare the activate date to now, to determine if the JobAlert period has started
     if ($now->getTimestamp() > $activateDate->getTimestamp()) {
-
         // If the deactivate date has been set,
         // calculate if the Job Alert period has already ended
         // If it hasn't been set then assume the Job Alert period is active now.
         $ended = false;
 
-        if ($deactivateDateString = get_field('job_alert_deactivate_date') ) {
+        if ($deactivateDateString = get_field('job_alert_deactivate_date')) {
             $deactivateDate = DateTime::createFromFormat('Y-m-d H:i:s', $deactivateDateString, $timeZone);
             $ended          = $now->getTimestamp() > $deactivateDate->getTimestamp();
         }
 
-        if ( ! $ended ) {
+        if (! $ended) {
             $jobAlertHTML = get_field('job_alert_text');
         }
     }
@@ -57,10 +55,8 @@ if ( (bool)get_field('job_alert_active') && $activateDateString = get_field('job
 
     <find-a-job job-title="<?= $jobTitle ?>" leg="<?= $leg ?>" >
 
-        <?php if ($jobAlertHTML): ?>
-
+        <?php if ($jobAlertHTML) : ?>
             <template slot="jobAlertHTML"><?= $jobAlertHTML ?></template>
-
         <?php endif; ?>
 
     </find-a-job>

--- a/web/app/themes/ppj/src/sass/colors.sass
+++ b/web/app/themes/ppj/src/sass/colors.sass
@@ -1,3 +1,11 @@
+$color-1: rgb(0,153,204)
+$color-2: rgb(160,0,102)
+$color-3: rgb(0,166,133)
+$color-4: rgb(77,66,223)
+$color-5: rgb(231,59,41)
+$color-6: rgb(0,166,147)
+$color-7: rgb(251,100,0)
+
 $color-dark-transparent: rgba(0,0,0,0.85)
 $color-medium-transparent: rgba(0,0,0,0.3)
 $color-white: #fff
@@ -24,11 +32,4 @@ $color-gradient-light: $color-dark-section
 
 $color-notification: lightyellow
 $color-warning: #fee
-
-$color-1: rgb(0,153,204)
-$color-2: rgb(160,0,102)
-$color-3: rgb(0,166,133)
-$color-4: rgb(77,66,223)
-$color-5: rgb(231,59,41)
-$color-6: rgb(0,166,147)
-$color-7: rgb(251,100,0)
+$color-job-alert: $color-8

--- a/web/app/themes/ppj/src/sass/components/find-a-job.sass
+++ b/web/app/themes/ppj/src/sass/components/find-a-job.sass
@@ -403,6 +403,26 @@
     .youth-custody &
       display: block
 
+  &__job-alert
+    color: $color-job-alert
+    border: .4rem solid $color-job-alert
+    border-radius: 2rem
+    line-height: 1.5
+    margin-bottom: 2rem
+    margin-top: .8rem
+    padding: 4rem
+    text-align: left
+
+    p
+      margin-top: 1rem
+      margin-bottom: 0
+
+      &:first-child
+        margin-top: 0
+
+    a
+      color: $color-job-alert
+
   &__map
     display: flex
     height: 24rem

--- a/web/app/themes/ppj/src/sass/prison-officer.sass
+++ b/web/app/themes/ppj/src/sass/prison-officer.sass
@@ -2,6 +2,7 @@
 
 $color-main: $color-1
 $color-tertiary: $color-2
+$color-jobalert: $color-2
 
 @import 'main'
 

--- a/web/app/themes/ppj/src/sass/youth-custody.sass
+++ b/web/app/themes/ppj/src/sass/youth-custody.sass
@@ -2,6 +2,7 @@
 
 $color-main: $color-3
 $color-tertiary: $color-4
+$color-job-alert: $color-4
 
 @import 'main'
 

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -139,7 +139,14 @@
               <a :href="jobListMessageUrlWithSearchTerm">{{ jobListMessage }}</a>
             </div>
           </li>
+
+          <li v-if="!!this.$slots['jobAlertHTML']">
+            <div class="find-a-job__job-alert">
+              <slot name="jobAlertHTML"></slot>
+            </div>
+          </li>
         </ul>
+
         <div class="find-a-job__pagination"
              v-if="deviceIsMobile && (numberOfResultPages > 1)">
           <a class="find-a-job__pagination-skip-link"
@@ -897,7 +904,7 @@
           currentState['lng1'] = this.map.currentBounds.getNorthEast().lng();
         }
         return currentState;
-      }
+      },
     },
 
     created() {


### PR DESCRIPTION
For a period of two weeks (but perhaps longer) there will be a significantly reduced number of jobs on the site.
During this time, we would like to capture the email addresses of users that end up on the find-a-job page
so that we can notify them in the future when more jobs are available.

The JAM will only display for a given leg's find-a-job page, if the JAM has been activated in the backend
using the relevant check box AND the 'Job alert activate date' is in the past.

If the above conditions are met and the 'Job alert deactivate date' is not set,
then the JAM will display indefinitely.
However if the 'Job alert deactivate date' is in the past, then the JAM will not be displayed,
regardless of the above settings.

The text of the JAM can be specified by the relevant WYSIWIG field on the 'find-a-job' page settings.