### PR TITLE
Remove Optimize script

### DIFF
--- a/web/app/themes/ppj/header.php
+++ b/web/app/themes/ppj/header.php
@@ -48,9 +48,6 @@
             })(window, document, 'script', 'dataLayer', 'GTM-N2SCJMC');</script>
         <!-- End Google Tag Manager -->
 
-        <!-- Optimise tag -->
-        <script src="https://www.googleoptimize.com/optimize.js?id=OPT-WMXKRDM"></script>
-
         <?php wp_head(); ?>
         <script><?php // code that must be available before the HTML has finished loading. ?>
             window.ppj = {};


### PR DESCRIPTION
After investigating the cookies that it uses, we've decided that we can't use Optimize for our cookie banner experiment. So, this PR removes the code which allows us to use it.