### PR TITLE
Remove JS opacity to fix Safari bug

### DIFF
--- a/web/app/themes/ppj/src/js/main.js
+++ b/web/app/themes/ppj/src/js/main.js
@@ -85,10 +85,6 @@ window.addEventListener('load', function() {
     )
   }
 
-  // hide html until Vue has rendered
-  const html = document.getElementsByTagName('html')[0];
-  html.style.opacity = 1;
-
 
 }, false);
 


### PR DESCRIPTION
There is currently an issue where the 'rewards and benefits' pages aren't displaying in Safari. This is currently because the JS turns the visibility of the page off until it's finished rendering. For some reason we don't fully understand, this function isn't picking up that the page has finished rendering on these types of pages. There is likely an underlying issue somewhere to do with a script not finishing, but for now this removes the JS which stops it from happening, and all the content is present.

I've tested this in Firefox, Safari and Chrome. The pages load, and the content all looks okay, and is now fully visible in Safari.§:wq