### PR TITLE
New Feature for Salary Ranges

### DIFF
--- a/web/app/themes/ppj/src/sass/components/job-summary.sass
+++ b/web/app/themes/ppj/src/sass/components/job-summary.sass
@@ -1,6 +1,6 @@
 .job-summary
   $verticalPadding: $common-spacing / 2
-  $salaryWidth: 8.5rem
+  $salaryWidth: 14rem
 
   background-color: inherit
   font-size: $font-size-small
@@ -62,7 +62,7 @@
     background-color: inherit
     font-weight: $font-weight-bold
     margin-left: auto
-    padding-left: $common-spacing
+    padding-left: 1rem
     text-align: right
     width: $salaryWidth
 

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -329,8 +329,8 @@
 
       switch(this.leg) {
         case 'prison-officer':
-          data.vacanciesDataURL = 'https://hmpps-feed-parser.s3.eu-west-2.amazonaws.com/dev/vacancies-test.json';
-          //data.vacanciesDataURL = 'https://s3.eu-west-2.amazonaws.com/hmpps-feed-parser/vacancies.json';
+          data.vacanciesDataURL = 'https://s3.eu-west-2.amazonaws.com/hmpps-feed-parser/vacancies.json';
+          //data.vacanciesDataURL = 'https://hmpps-feed-parser.s3.eu-west-2.amazonaws.com/dev/vacancies-test.json';
           //data.vacanciesDataURL = 'https://s3.eu-west-2.amazonaws.com/hmpps-feed-parser/prod/vacancies.json';
           break;
 

--- a/web/app/themes/ppj/src/vue/FindAJob.vue
+++ b/web/app/themes/ppj/src/vue/FindAJob.vue
@@ -329,7 +329,8 @@
 
       switch(this.leg) {
         case 'prison-officer':
-          data.vacanciesDataURL = 'https://s3.eu-west-2.amazonaws.com/hmpps-feed-parser/vacancies.json';
+          data.vacanciesDataURL = 'https://hmpps-feed-parser.s3.eu-west-2.amazonaws.com/dev/vacancies-test.json';
+          //data.vacanciesDataURL = 'https://s3.eu-west-2.amazonaws.com/hmpps-feed-parser/vacancies.json';
           //data.vacanciesDataURL = 'https://s3.eu-west-2.amazonaws.com/hmpps-feed-parser/prod/vacancies.json';
           break;
 

--- a/web/app/themes/ppj/src/vue/JobSummary.vue
+++ b/web/app/themes/ppj/src/vue/JobSummary.vue
@@ -79,7 +79,12 @@
             var salary_range = this.salary.split('-');
 
             if(salary_range.length == 2) {
-              return '£' + Intl.NumberFormat().format(salary_range[0]) + ' - £' + Intl.NumberFormat().format(salary_range[1]);
+              if(isNaN(salary_range[0]) == false && isNaN(salary_range[1]) == false) {
+                return '£' + Intl.NumberFormat().format(salary_range[0]) + ' - £' + Intl.NumberFormat().format(salary_range[1]);
+              }
+              else {
+                return '';
+              }
             }
 
           }

--- a/web/app/themes/ppj/src/vue/JobSummary.vue
+++ b/web/app/themes/ppj/src/vue/JobSummary.vue
@@ -73,7 +73,21 @@
       },
 
       formattedSalary: function() {
-        return '£' + Intl.NumberFormat().format(this.salary)
+
+        if(isNaN(this.salary)) {
+          if(this.salary.includes('-')){
+            var salary_range = this.salary.split('-');
+
+            if(salary_range.length == 2) {
+              return '£' + Intl.NumberFormat().format(salary_range[0]) + ' - £' + Intl.NumberFormat().format(salary_range[1]);
+            }
+
+          }
+          return '';
+        }
+        else {
+          return '£' + Intl.NumberFormat().format(this.salary);
+        }
       },
     },
   }


### PR DESCRIPTION
Currently Salary ranges result in a NAN on PPJ. This new feature should hopefully handle salary ranges.

Needs to be tested with job from Olleo to double check '-' character is the right character used. I looked at justice jobs and it seems to be using this character in the feed for ranges.

Possibly also add a trim and NAN check on the salary_range[0] and salary_range[1] .

